### PR TITLE
fix: strip unknown keys from image generation config before sending to Bedrock

### DIFF
--- a/image.go
+++ b/image.go
@@ -133,6 +133,9 @@ var modernStabilityConfigKeys = map[string]struct{}{
 // allowed, so unrecognized fields (e.g. a secret accidentally left in a
 // shared config map) never reach the outbound request body.
 func mergeAllowedConfig(dst, src map[string]any, allowed map[string]struct{}) {
+	if dst == nil {
+		return
+	}
 	for k, v := range src {
 		if _, ok := allowed[k]; ok {
 			dst[k] = v
@@ -186,7 +189,9 @@ func (b *Bedrock) generateTitanImage(ctx context.Context, modelName, prompt stri
 		if configMap, ok := config.(map[string]any); ok {
 			if imageConfig, exists := configMap["imageGenerationConfig"]; exists {
 				if imgCfg, ok := imageConfig.(map[string]any); ok {
-					mergeAllowedConfig(requestBody["imageGenerationConfig"].(map[string]any), imgCfg, imageGenerationConfigKeys)
+					if targetCfg, ok := requestBody["imageGenerationConfig"].(map[string]any); ok {
+						mergeAllowedConfig(targetCfg, imgCfg, imageGenerationConfigKeys)
+					}
 				}
 			}
 		}
@@ -376,7 +381,9 @@ func (b *Bedrock) generateNovaCanvasImage(ctx context.Context, modelName, prompt
 		if configMap, ok := config.(map[string]any); ok {
 			if imageConfig, exists := configMap["imageGenerationConfig"]; exists {
 				if imgCfg, ok := imageConfig.(map[string]any); ok {
-					mergeAllowedConfig(requestBody["imageGenerationConfig"].(map[string]any), imgCfg, imageGenerationConfigKeys)
+					if targetCfg, ok := requestBody["imageGenerationConfig"].(map[string]any); ok {
+						mergeAllowedConfig(targetCfg, imgCfg, imageGenerationConfigKeys)
+					}
 				}
 			}
 		}

--- a/image.go
+++ b/image.go
@@ -86,6 +86,60 @@ func isModernStabilityImageModel(modelName string) bool {
 	return strings.Contains(modelName, "sd3-") || strings.Contains(modelName, "stable-image")
 }
 
+// imageGenerationConfigKeys are the recognized fields inside the nested
+// imageGenerationConfig object accepted by Titan Image Generator and Nova
+// Canvas. Callers pass config as a freeform map[string]any (imageConfigSchema
+// intentionally has no property restrictions, since each model family has a
+// different shape), so we allow-list the fields we forward rather than
+// copying the map verbatim into the outbound request body.
+var imageGenerationConfigKeys = map[string]struct{}{
+	"numberOfImages": {},
+	"quality":        {},
+	"height":         {},
+	"width":          {},
+	"cfgScale":       {},
+	"seed":           {},
+}
+
+// legacyStabilityConfigKeys are the recognized top-level fields for legacy
+// Stable Diffusion (stability.stable-diffusion-*) requests.
+var legacyStabilityConfigKeys = map[string]struct{}{
+	"cfg_scale":            {},
+	"clip_guidance_preset": {},
+	"height":               {},
+	"width":                {},
+	"samples":              {},
+	"steps":                {},
+	"seed":                 {},
+	"style_preset":         {},
+	"sampler":              {},
+	"extras":               {},
+}
+
+// modernStabilityConfigKeys are the recognized top-level fields for modern
+// Stability (stability.sd3-*, stability.stable-image-*) requests.
+var modernStabilityConfigKeys = map[string]struct{}{
+	"mode":            {},
+	"aspect_ratio":    {},
+	"negative_prompt": {},
+	"seed":            {},
+	"output_format":   {},
+	"style_preset":    {},
+	"cfg_scale":       {},
+	"strength":        {},
+}
+
+// mergeAllowedConfig copies from src into dst only the keys present in
+// allowed, so unrecognized fields (e.g. a secret accidentally left in a
+// shared config map) never reach the outbound request body.
+func mergeAllowedConfig(dst, src map[string]any, allowed map[string]struct{}) {
+	for k, v := range src {
+		if _, ok := allowed[k]; ok {
+			dst[k] = v
+		}
+	}
+}
+
 func imageResponse(input *ai.ModelRequest, images []string) (*ai.ModelResponse, error) {
 	if len(images) == 0 {
 		return nil, fmt.Errorf("no images generated")
@@ -132,9 +186,7 @@ func (b *Bedrock) generateTitanImage(ctx context.Context, modelName, prompt stri
 		if configMap, ok := config.(map[string]any); ok {
 			if imageConfig, exists := configMap["imageGenerationConfig"]; exists {
 				if imgCfg, ok := imageConfig.(map[string]any); ok {
-					for k, v := range imgCfg {
-						requestBody["imageGenerationConfig"].(map[string]any)[k] = v
-					}
+					mergeAllowedConfig(requestBody["imageGenerationConfig"].(map[string]any), imgCfg, imageGenerationConfigKeys)
 				}
 			}
 		}
@@ -198,9 +250,7 @@ func (b *Bedrock) generateStableDiffusionImage(ctx context.Context, modelName, p
 	// Apply config if provided
 	if config != nil {
 		if configMap, ok := config.(map[string]any); ok {
-			for k, v := range configMap {
-				requestBody[k] = v
-			}
+			mergeAllowedConfig(requestBody, configMap, legacyStabilityConfigKeys)
 		}
 	}
 
@@ -260,9 +310,7 @@ func (b *Bedrock) generateModernStabilityImage(ctx context.Context, modelName, p
 	}
 	if config != nil {
 		if configMap, ok := config.(map[string]any); ok {
-			for k, v := range configMap {
-				requestBody[k] = v
-			}
+			mergeAllowedConfig(requestBody, configMap, modernStabilityConfigKeys)
 		}
 	}
 
@@ -328,9 +376,7 @@ func (b *Bedrock) generateNovaCanvasImage(ctx context.Context, modelName, prompt
 		if configMap, ok := config.(map[string]any); ok {
 			if imageConfig, exists := configMap["imageGenerationConfig"]; exists {
 				if imgCfg, ok := imageConfig.(map[string]any); ok {
-					for k, v := range imgCfg {
-						requestBody["imageGenerationConfig"].(map[string]any)[k] = v
-					}
+					mergeAllowedConfig(requestBody["imageGenerationConfig"].(map[string]any), imgCfg, imageGenerationConfigKeys)
 				}
 			}
 		}

--- a/image_test.go
+++ b/image_test.go
@@ -389,6 +389,70 @@ func TestGenerateImage_ConfigOverridesSurviveGenkitSchemaValidation(t *testing.T
 	}
 }
 
+func TestGenerateImage_UnknownConfigKeysAreStripped(t *testing.T) {
+	tests := []struct {
+		name   string
+		model  string
+		config map[string]any
+	}{
+		{
+			name:   "titan nested imageGenerationConfig",
+			model:  "amazon.titan-image-generator-v1",
+			config: map[string]any{"imageGenerationConfig": map[string]any{"apiKey": "secret", "seed": 7}},
+		},
+		{
+			name:   "nova canvas nested imageGenerationConfig",
+			model:  "amazon.nova-canvas-v1:0",
+			config: map[string]any{"imageGenerationConfig": map[string]any{"apiKey": "secret", "quality": "premium"}},
+		},
+		{
+			name:   "legacy stable diffusion top-level",
+			model:  "stability.stable-diffusion-xl-v1:0",
+			config: map[string]any{"apiKey": "secret", "cfg_scale": 10},
+		},
+		{
+			name:   "modern stability top-level",
+			model:  "stability.sd3-large-v1:0",
+			config: map[string]any{"apiKey": "secret", "aspect_ratio": "16:9"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				if err := json.Unmarshal(body, &gotBody); err != nil {
+					t.Errorf("unmarshal request body: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"images":["img"],"artifacts":[{"base64":"img","finishReason":"SUCCESS"}],"finish_reasons":["SUCCESS"]}`)
+			}))
+			defer server.Close()
+
+			b := newTestBedrock(server)
+			req := imagePromptRequest("prompt")
+			req.Config = tt.config
+
+			if _, err := b.generateImage(context.Background(), tt.model, req, nil); err != nil {
+				t.Fatalf("generateImage error: %v", err)
+			}
+
+			if raw, err := json.Marshal(gotBody); err == nil && strings.Contains(string(raw), "secret") {
+				t.Fatalf("request body leaked unknown config key: %s", raw)
+			}
+			if cfg, ok := gotBody["imageGenerationConfig"].(map[string]any); ok {
+				if _, ok := cfg["apiKey"]; ok {
+					t.Fatalf("imageGenerationConfig retained unknown key apiKey: %v", cfg)
+				}
+			}
+			if _, ok := gotBody["apiKey"]; ok {
+				t.Fatalf("request body retained unknown top-level key apiKey: %v", gotBody)
+			}
+		})
+	}
+}
+
 func imagePromptRequest(prompt string) *ai.ModelRequest {
 	return &ai.ModelRequest{
 		Messages: []*ai.Message{


### PR DESCRIPTION
## Description

This PR strips unknown keys from image generation config before sending to Bedrock.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update


## Testing

Please describe the tests that you ran to verify your changes:

- [x] Unit tests pass (`go test ./...`)
- [x] Integration tests pass
- [x] Manual testing performed
- [x] Examples still work

### Test Configuration

- Go version: 
- AWS Bedrock models tested: 
- Operating system: 

## Code Quality

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works

## Documentation

- [x] Updated README.md if needed
- [x] Updated code comments
- [x] Added examples if introducing new features
- [x] Updated API documentation

## AWS Bedrock Specific

If this change affects AWS Bedrock functionality:

- [x] Tested with multiple Bedrock models
- [x] Verified AWS credential handling
- [x] Checked error handling for AWS API calls
- [x] Validated streaming functionality (if applicable)
- [x] Tested tool calling features (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document
- [x] I have signed the CLA (if required)
- [x] My commits follow the conventional commit format
- [x] I have updated the version number (if applicable)
